### PR TITLE
Changed logging level from 'Error' to 'Warning' to fix build when ini…

### DIFF
--- a/Plugins/ManusVR/Source/ManusVR/Private/ManusVR.cpp
+++ b/Plugins/ManusVR/Source/ManusVR/Private/ManusVR.cpp
@@ -29,7 +29,7 @@ const FKey EManus::Right_Pinky("ManusRightPinky");
 
 void FManusVRModule::StartupModule()
 {
-	UE_LOG(LogManusVR, Error, TEXT("Initialising Manus Library"));
+	UE_LOG(LogManusVR, Log, TEXT("Initialising Manus Library"));
 
 	FString filePath = FPaths::Combine(*FPaths::GamePluginsDir(), 
 		TEXT("ManusVR/ThirdParty/Manus/lib"), 
@@ -51,12 +51,12 @@ void FManusVRModule::StartupModule()
 		}
 		else
 		{
-			UE_LOG(LogManusVR, Error, TEXT("Cannot Obtain DLL Handle"))
+			UE_LOG(LogManusVR, Warning, TEXT("Cannot Obtain DLL Handle"))
 		}
 	}
 	else
 	{
-		UE_LOG(LogManusVR, Error, TEXT("Cannot Find DLL %s"), *filePath)
+		UE_LOG(LogManusVR, Warning, TEXT("Cannot Find DLL %s"), *filePath)
 	}
 
 	if (_ManusInit) {

--- a/Plugins/ManusVR/Source/ManusVR/Private/ManusVRAnimInstance.cpp
+++ b/Plugins/ManusVR/Source/ManusVR/Private/ManusVRAnimInstance.cpp
@@ -58,11 +58,11 @@ bool UManusVRAnimInstance::NativeEvaluateAnimation(struct FPoseContext& Output)
 	if (HandAnimation == NULL)
 	{
 		if (isLeft) {
-			UE_LOG(LogManusVRAnimation, Error, TEXT("Animation not set for left glove"));
+			UE_LOG(LogManusVRAnimation, Warning, TEXT("Animation not set for left glove"));
 		}
 		else
 		{
-			UE_LOG(LogManusVRAnimation, Error, TEXT("Animation not set for right glove"));
+			UE_LOG(LogManusVRAnimation, Warning, TEXT("Animation not set for right glove"));
 		}	
 		return true;
 	}
@@ -76,11 +76,11 @@ bool UManusVRAnimInstance::NativeEvaluateAnimation(struct FPoseContext& Output)
 		if (retval != MANUS_SUCCESS){
 			Output.ResetToRefPose();
 			if (isLeft) {
-				UE_LOG(LogManusVRAnimation, Error, TEXT("Unable to obtain data from left glove"))
+				UE_LOG(LogManusVRAnimation, Warning, TEXT("Unable to obtain data from left glove"))
 			}
 			else
 			{
-				UE_LOG(LogManusVRAnimation, Error, TEXT("Unable to obtain data from right glove"))
+				UE_LOG(LogManusVRAnimation, Warning, TEXT("Unable to obtain data from right glove"))
 			}
 			return true;
 		}


### PR DESCRIPTION
When the build is initiated from the Unreal Editor, a log message with the level of "Error" will trigger a build failure. This does not cause a failure when the build is initiated from Microsoft Visual Studio. All Error messages have been reduced to Warning messages. (The initialisation message has been turned into a Log message)  