### PR TITLE
4.12 Support/Plugin Compilation Fix

### DIFF
--- a/ManusUnrealDemo.uproject
+++ b/ManusUnrealDemo.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.11",
+	"EngineAssociation": "4.12",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/Plugins/ManusVR/Source/ManusVR/ManusVR.Build.cs
+++ b/Plugins/ManusVR/Source/ManusVR/ManusVR.Build.cs
@@ -8,7 +8,7 @@ public class ManusVR : ModuleRules
 {
     private string ModulePath
     {
-        get { return ModuleDirectory; //.../ThirdParty/ }
+        get { return ModuleDirectory; } //.../ThirdParty/ }
     }
 
     private string ThirdPartyPath


### PR DESCRIPTION
This pull request:

1. Improves support for 4.12 introduced in f43af43 by changing the engine association from 4.11 to 4.12
2. Fixes an issue compiling the Manus plugin due to a commented-out closing bracket introduced in f43af43 (this was tested with Engine 4.12.5).
